### PR TITLE
Adding a snippet for routes in config + allowing multiple arguments in the controller snippet

### DIFF
--- a/snippets/controller.sublime-snippet
+++ b/snippets/controller.sublime-snippet
@@ -1,8 +1,10 @@
 <snippet>
 	<content><![CDATA[
-controller('${1:Name}Ctrl', ['${2:\$scope}', $4function (${2:\$scope}$3) {
-	$0
-}])
+controller('${1:Name}Ctrl', ['${2/,[ ]?/', '/g}',
+  $3function (${2:\$scope}) {
+    $0
+  }
+])
 ]]></content>
 	<tabTrigger>controller</tabTrigger>
 	<scope>source.js</scope>

--- a/snippets/router.sublime-snippet
+++ b/snippets/router.sublime-snippet
@@ -1,0 +1,13 @@
+<snippet>
+	<content><![CDATA[  .when( '/${1:route}', {
+    templateUrl:  '${1}.html',
+    controller:   '${1/([A-Za-z0-9]+)?/(?2::\u$1)/g}Ctrl' })
+  ${2:.when( '/${3:route}', {
+    templateUrl:  '${3}.html',
+    controller:   '${3/([A-Za-z0-9]+)?/(?2::\u$1)/g}Ctrl' })
+  .otherwise({ redirectTo: '/login' });
+]]></content>
+	<tabTrigger>route</tabTrigger>
+	<scope>source.js</scope>
+	<description>Angular.js - Route</description>
+</snippet>


### PR DESCRIPTION
# Adding a snippet for routes in config

I see another snippet for config, so added this for quick route insertion.
# Allowing multiple arguments in the controller snippet

Previously snippet took in just one parameter $scope. Modified this allow multiple parameters and format them correctly with , and quotes.
